### PR TITLE
fix: define devServer to prevent exception in devSocket.

### DIFF
--- a/lib/server/cra.js
+++ b/lib/server/cra.js
@@ -17,13 +17,19 @@ const useYarn = fs.existsSync(paths.yarnLockFile);
 module.exports = async function Server(app, { host, port }) {
   const config = configFactory('development');
   const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
-  const { name: appName, proxy: proxySetting } = require(paths.appPackageJson).name;
+  const {
+    name: appName,
+    proxy: proxySetting,
+  } = require(paths.appPackageJson).name;
   const useTypeScript = fs.existsSync(paths.appTsConfig);
   const urls = prepareUrls(protocol, host, port);
+
   const devSocket = {
-    warnings: warnings => devServer.sockWrite(devServer.sockets, 'warnings', warnings),
+    warnings: warnings =>
+      devServer.sockWrite(devServer.sockets, 'warnings', warnings),
     errors: errors => devServer.sockWrite(devServer.sockets, 'errors', errors),
   };
+
   // Create a webpack compiler that is configured with custom messages.
   const compiler = createCompiler({
     appName,
@@ -43,5 +49,6 @@ module.exports = async function Server(app, { host, port }) {
     devServerApp.use(app);
     return before && before(devServerApp, server);
   };
-  return new WebpackDevServer(compiler, serverConfig);
+  const devServer = new WebpackDevServer(compiler, serverConfig);
+  return devServer;
 };


### PR DESCRIPTION
Adds a const `devServer` as it is used in 
```
const devSocket = {
    warnings: warnings => devServer.sockWrite(devServer.sockets, 'warnings', warnings),	    warnings: warnings =>
      devServer.sockWrite(devServer.sockets, 'warnings', warnings),
    errors: errors => devServer.sockWrite(devServer.sockets, 'errors', errors),	    errors: errors => devServer.sockWrite(devServer.sockets, 'errors', errors),
  };	  };
```

...

```
const devServer = new WebpackDevServer(compiler, serverConfig);
return devServer;
```